### PR TITLE
Add styling to the RulesBlock 'see all' button

### DIFF
--- a/src/blocks/RulesBlock.tsx
+++ b/src/blocks/RulesBlock.tsx
@@ -6,7 +6,7 @@ import css from "styled-jsx/css";
 const { className: linkClassName, styles: linkStyles } = css.resolve`
   a,
   button {
-    text-decoration: underline;
+    text-decoration: none;
     color: #f96680;
   }
 `;

--- a/src/blocks/RulesBlock.tsx
+++ b/src/blocks/RulesBlock.tsx
@@ -1,6 +1,15 @@
 import ActionLink from "../buttons/ActionLink";
 import { LinkWithAction } from "../types";
 import React from "react";
+import css from "styled-jsx/css";
+
+const { className: linkClassName, styles: linkStyles } = css.resolve`
+  a,
+  button {
+    text-decoration: underline;
+    color: #f96680;
+  }
+`;
 
 const RulesBlockHeader: React.FC<{
   title: string;
@@ -9,11 +18,7 @@ const RulesBlockHeader: React.FC<{
   return (
     <div className="rules-header">
       <h2>{title}</h2>
-      <ActionLink
-        link={seeAllLink}
-        label="See all the rules"
-        className="rules-link"
-      >
+      <ActionLink className={linkClassName} link={seeAllLink}>
         See All
       </ActionLink>
       <style jsx>{`
@@ -24,13 +29,8 @@ const RulesBlockHeader: React.FC<{
           padding: 6px;
           height: 1.2em;
         }
-        .rules-link {
-          color: #888;
-          text-decoration: none;
-          height: 1.2em;
-          padding: 0px 6px;
-        }
       `}</style>
+      {linkStyles}
     </div>
   );
 };

--- a/src/blocks/RulesBlock.tsx
+++ b/src/blocks/RulesBlock.tsx
@@ -48,7 +48,7 @@ const RuleDisplay: React.FC<{ rule: Rule }> = ({ rule }) => {
           border: 2px solid #1c1c1c;
           border-radius: 15px;
           padding: 0.5em 0.5em 0;
-          background-color: #2f2f30;
+          background-color: #1c1c1c;
           color: white;
           margin: 6px;
         }
@@ -63,11 +63,15 @@ const RuleDisplay: React.FC<{ rule: Rule }> = ({ rule }) => {
 
         details[open] {
           padding: 0.5em;
+          border: 2px solid #1c1c1c;
+          background-color: #2f2f30;
         }
 
         details[open] summary {
+          background-color: #1c1c1c;
+          border: unset;
           margin-bottom: 0.5em;
-          border-radius: 15px 15px 0px 0px;
+          border-radius: 12px 12px 0px 0px;
         }
       `}</style>
     </li>
@@ -85,7 +89,7 @@ const RulesList: React.FC<{ rules: Rule[] }> = ({ rules }) => {
       <style jsx>{`
         ul {
           list-style: none;
-          margin: 6px 0px;
+          margin: 0px;
           padding: 0px;
         }
       `}</style>


### PR DESCRIPTION
Didn't use the DefaultTheme color because it didn't pass accessibility contrast guidelines, but I can put that back in. 
(And removed the label from the link because that was also not correct per a11y guidelines)