### PR TITLE
remove useless isomorphic layout effect on loading bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "react-toastify": "^8.1.0",
     "resize-observer-polyfill": "^1.5.1",
     "tty-browserify": "^0.0.1",
-    "use-isomorphic-layout-effect": "^1.1.2",
     "use-state-with-callback": "^2.0.3",
     "uuid": "^8.3.0"
   },

--- a/src/common/LoadingBar.tsx
+++ b/src/common/LoadingBar.tsx
@@ -1,7 +1,6 @@
 import Color from "color";
 import React from "react";
 import classnames from "classnames";
-import useLayoutEffect from "use-isomorphic-layout-effect";
 
 const HEIGHT = 1;
 const INCREASE_INTERVAL = 700;
@@ -20,7 +19,7 @@ const LoadingBar = (props: LoadingBarProps) => {
   const progressTimeout = React.useRef<NodeJS.Timeout>();
   const barRef = React.useRef<HTMLDivElement>(null);
 
-  useLayoutEffect(() => {
+  React.useEffect(() => {
     if (!props.loading) {
       if (progressTimeout.current && barRef.current) {
         clearTimeout(progressTimeout.current);

--- a/yarn.lock
+++ b/yarn.lock
@@ -14153,11 +14153,6 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-use-isomorphic-layout-effect@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz#497cefb13d863d687b08477d9e5a164ad8c1a6fb"
-  integrity sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==
-
 use-state-with-callback@^2.0.3:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/use-state-with-callback/-/use-state-with-callback-2.0.5.tgz#d4098fd7c5cdf2af2be8dbed30fda206db4585b9"


### PR DESCRIPTION
It supposedly was there to avoid the SSR error, but it didn't seem to actually do that. Tried without `useLayoutEffect` and things seem to work well enough regardless.